### PR TITLE
fix(zsh): modefy source code folder path development to develop

### DIFF
--- a/zsh/global_env.zsh
+++ b/zsh/global_env.zsh
@@ -5,7 +5,7 @@ export SVN_EDITOR="${EDITOR}"
 export GIT_EDITOR="${EDITOR}"
 
 # include home folder with cd command path
-export CDPATH=$HOME:$HOME/development:$HOME/doc:/usr/local
+export CDPATH=$HOME:$HOME/develop:$HOME/doc:/usr/local
 
 # history
 # size recorded on memory


### PR DESCRIPTION
Renaming to development cause some errors such as IDE lose project paths

