### PR TITLE
modefy some settings of nvim, tmux and git

### DIFF
--- a/.ide-vimrc
+++ b/.ide-vimrc
@@ -50,7 +50,7 @@ set smartcase
 " hilight search words"
 set hlsearch
 "hilight off in two ESC times"
-nmap <silent> <Esc><Esc> ;nohlsearch<CR>
+" nmap <silent> <Esc><Esc> ;nohlsearch<CR>
 
 
 "codesnipetts"

--- a/gitconfig/.gitconfig_shared
+++ b/gitconfig/.gitconfig_shared
@@ -20,3 +20,6 @@
     poc = push origin `git rev-parse --abbrev-ref HEAD`
     bra = branch -a
     md = merge develop
+[core]
+	editor = nvim
+

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -3,7 +3,8 @@ require("keymaps")
 
 -- colorscheme settings
 vim.cmd 'set background=dark'
-vim.cmd 'colorscheme default'
+-- vim.cmd 'colorscheme default'
+vim.cmd 'colorscheme shine'
 
 
 -- activate vim loader to use plugin manager

--- a/zsh/global_setting.zsh
+++ b/zsh/global_setting.zsh
@@ -165,17 +165,29 @@ function ssh() {
     if [[ -n $(printenv TMUX) ]] ; then
         # 現在のペインIDを記録
         local pane_id=$(tmux display -p '#{pane_id}')
-        # 接続先ホスト名に応じて背景色を切り替え
-        # if [[ `echo $1 | grep 'prd'` ]] ; then
-        #     tmux select-pane -P 'bg=colour52,fg=white'
-        # elif [[ `echo $1 | grep 'stg'` ]] ; then
-        #     tmux select-pane -P 'bg=colour25,fg=white'
-        # fi
-        # tmux select-pane -P 'bg=colour58,fg=white'
+        #接続先ホスト名に応じて背景色を切り替え
+        if [[ `echo $1 | grep 'prod'` ]] ; then
+            tmux select-pane -P 'bg=colour52,fg=white'
+        elif [[ `echo $1 | grep 'vl'` ]] ; then
+            tmux select-pane -P 'bg=colour52,fg=white'
+        # test環境はec2端末ごとに色味の違いがあり、共通して見やすい色が設定できないため適用対象外とする
+        #elif [[ `echo $1 | grep 'st'` ]] ; then
+            #tmux select-pane -P 'bg=gray,fg=black'
+            #tmux select-pane -P 'bg=green,fg=white'
+        #else
+            #tmux select-pane -P 'bg=green,fg=white'
+        fi
+        #tmux select-pane -P 'bg=colour58,fg=white'
+        #tmux select-pane -P 'bg=colour52,fg=white'
+        #tmux select-pane -P 'bg=colour9,fg=white'
+        #tmux select-pane -P 'bg=colour182,fg=black'
+        #tmux select-pane -P 'bg=palevioletred,fg=black'
+        #tmux select-pane -P 'bg=darkkhaki,fg=black'
+        #tmux select-pane -P 'bg=olive,fg=white'
+        #tmux select-pane -P 'bg=lightsteelblue,fg=black'
+        #tmux select-pane -P 'bg=lightslategray,fg=black'
 
-        tmux select-pane -P 'bg=colour52,fg=white'
-
-        # 通常通りssh続行
+       # 通常通りssh続行
         command ssh $@
 
       # デフォルトの背景色に戻す


### PR DESCRIPTION
- **fix(ide-vim): comment out esc*2 to nohlsearch**
- **feat(git): set git default editor to nvim**
- **feat(nvim): set nvim default color to shine**
- **feat(tmux): set background color to red when accessing to production**

